### PR TITLE
Web access to view burp logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Please see [this blog post](https://teamrot.fi/2019/05/23/self-hosted-burp-colla
 1. Clone this repository.
 2. Place your burp jar to the privatecollaborator-directory.
 3. Run `sudo ./install.sh your.domain.fi`.
+    - it will ask for a basic auth password for HTTP log view
+    - https://your.domain.fi:1337/ - will serve burp collaborator logs (just basic interaction logs) - for fast checks without burp client
 4. You should now have Let's encrypt certificate for the domain and a private burp collaborator properly set up.
 5. Start the collaborator with `sudo service burpcollaborator start`.
 6. Configure your Burp Suite Professional to use it.

--- a/install.sh
+++ b/install.sh
@@ -71,3 +71,19 @@ mkdir -p /usr/local/collaborator/keys/
 cp $CERT_PATH/privkey.pem /usr/local/collaborator/keys/
 cp $CERT_PATH/fullchain.pem /usr/local/collaborator/keys/
 cp $CERT_PATH/cert.pem /usr/local/collaborator/keys/
+
+# nginx log view
+apt install -y nginx apache2-utils
+sed -i "s/# server_tokens off;/server_tokens off;/g" /etc/nginx/nginx.conf
+rm -v /etc/nginx/sites-enabled/default
+cp logview/collaborator.conf /etc/nginx/sites-available/
+ln -s /etc/nginx/sites-available/collaborator.conf /etc/nginx/sites-enabled/collaborator.conf
+sed -i "s/BDOMAIN/$DOMAIN/g" /etc/nginx/sites-enabled/collaborator.conf
+cp logview/truncate-log /etc/cron.d/
+
+echo "Create collaborator view login:"
+htpasswd -c /etc/nginx/.htpasswd-collaborator collaborator
+mkdir /var/www/collaborator
+cp logview/index.html /var/www/collaborator/
+openssl dhparam -outform pem -out /etc/ssl/dhparam4096.pem 4096
+nginx -t && service nginx start

--- a/logview/collaborator.conf
+++ b/logview/collaborator.conf
@@ -1,0 +1,31 @@
+server {
+    listen       1337 ssl;
+    server_name  BDOMAIN;
+    root         /var/www/collaborator;
+
+    ssl_certificate "/etc/letsencrypt/live/BDOMAIN/fullchain.pem";
+    ssl_certificate_key "/etc/letsencrypt/live/BDOMAIN/privkey.pem";
+
+    ssl_dhparam /etc/ssl/dhparam4096.pem;
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256;
+
+    ssl_ecdh_curve secp384r1;
+    ssl_session_timeout 60m;
+    ssl_session_tickets off;
+
+    location / {
+        auth_basic "Please";
+        auth_basic_user_file /etc/nginx/.htpasswd-collaborator;
+        try_files $uri $uri/ =404;
+    }
+
+    error_page 404 /404.html;
+        location = /40x.html {
+    }
+
+    error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+    }
+}

--- a/logview/index.html
+++ b/logview/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Collaborator logs</title>
+    <script type="text/javascript">
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState == XMLHttpRequest.DONE) {
+                document.getElementsByTagName("pre")[0].textContent = xhr.responseText;
+                window.scrollTo(0,document.body.scrollHeight)
+            }
+        }
+        xhr.withCredentials = true;
+        xhr.open('GET', '/burp.txt?'+Math.random(), true);
+        xhr.send(null);
+    </script>
+</head>
+<body>
+<pre></pre>
+</body>
+</html>

--- a/logview/truncate-log
+++ b/logview/truncate-log
@@ -1,0 +1,4 @@
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+* * * * * root test `wc -l /var/www/collaborator/burp.txt | cut -f1 -d" "` -gt "1024" && (tail -1024 /var/www/collaborator/burp.txt > /var/www/collaborator/burp2.txt; cp /var/www/collaborator/burp2.txt /var/www/collaborator/burp.txt; rm /var/www/collaborator/burp2.txt)

--- a/renewcert.sh
+++ b/renewcert.sh
@@ -35,3 +35,4 @@ systemctl is-active --quiet burpcollaborator
     --server https://acme-v02.api.letsencrypt.org/directory \
     --manual --agree-tos --no-eff-email --manual-public-ip-logging-ok --preferred-challenges dns-01
 
+service nginx reload

--- a/startcollab.sh
+++ b/startcollab.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-java -Xms10m -Xmx200m -XX:GCTimeRatio=19 -jar /usr/local/collaborator/burp*.jar --collaborator-server --collaborator-config=/usr/local/collaborator/collaborator.config
+java -Xms10m -Xmx200m -XX:GCTimeRatio=19 -jar /usr/local/collaborator/burp*.jar --collaborator-server --collaborator-config=/usr/local/collaborator/collaborator.config | grep --line-buffered -vE ' : Received HTTP[S]? polling request from \[' >> /var/www/collaborator/burp.txt


### PR DESCRIPTION
new functionality which set up web server at port https://domain:1337 with:

- basic auth
- here are served burp collaborator logs
- it enables fast review of burp collaborator interaction without burp client