### PR TITLE
Renewcert Fix and Metrics Default Configuration

### DIFF
--- a/collaborator.config
+++ b/collaborator.config
@@ -39,9 +39,10 @@
             "/usr/local/collaborator/keys/fullchain.pem" ]
     }
   }, 
-  "metrics": { 
-    "path" : "jnaicmez8", 
-  }, 
+  "metrics": {  
+   "path" : "burp-metrics-path", 
+   "addressWhitelist" : ["127.0.0.1/32"]
+  },
   "dns": { 
     "interfaces" : [{ 
       "name": "ns1.BDOMAIN", 

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,8 @@ sed -i "s/EXT_IP/$MYPUBLICIP/g" /usr/local/collaborator/collaborator.config
 sed -i "s/BDOMAIN/$DOMAIN/g" /usr/local/collaborator/collaborator.config
 cp burpcollaborator.service /etc/systemd/system/
 cp startcollab.sh /usr/local/collaborator/
+
+sed -i "s/BDOMAIN/$DOMAIN/g" renewcert.sh
 cp renewcert.sh /etc/cron.daily/
 
 cd /usr/local/collaborator/

--- a/renewcert.sh
+++ b/renewcert.sh
@@ -40,7 +40,6 @@ systemctl is-active --quiet burpcollaborator
 
 # Copy certifcates to collaborator directory
 CERT_PATH=/etc/letsencrypt/live/$DOMAIN
-rm /usr/local/collaborator/keys/*.pem
 cp $CERT_PATH/privkey.pem /usr/local/collaborator/keys/
 cp $CERT_PATH/fullchain.pem /usr/local/collaborator/keys/
 cp $CERT_PATH/cert.pem /usr/local/collaborator/keys/

--- a/renewcert.sh
+++ b/renewcert.sh
@@ -2,6 +2,9 @@
 
 # Yeah, my bash scripting skills suck.
 
+# Define domain name
+DOMAIN="BDOMAIN"
+
 # Use public IP in case not running on AWS or Digitalocean.
 MYPRIVATEIP=$(curl http://checkip.amazonaws.com/ -s)
 
@@ -35,3 +38,9 @@ systemctl is-active --quiet burpcollaborator
     --server https://acme-v02.api.letsencrypt.org/directory \
     --manual --agree-tos --no-eff-email --manual-public-ip-logging-ok --preferred-challenges dns-01
 
+# Copy certifcates to collaborator directory
+CERT_PATH=/etc/letsencrypt/live/$DOMAIN
+rm /usr/local/collaborator/keys/*.pem
+cp $CERT_PATH/privkey.pem /usr/local/collaborator/keys/
+cp $CERT_PATH/fullchain.pem /usr/local/collaborator/keys/
+cp $CERT_PATH/cert.pem /usr/local/collaborator/keys/


### PR DESCRIPTION
Addresses #7 
* Restricts metrics path by default to localhost
* Use a non-default metrics path name

Addresses #9 
* Add certificate copy on certificate renewal
