### PR TITLE
Limit memory usage for burp collaborator

### DIFF
--- a/startcollab.sh
+++ b/startcollab.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/opt/BurpSuitePro/BurpSuitePro --collaborator-server --collaborator-config=/usr/local/collaborator/collaborator.config
+/opt/BurpSuitePro/BurpSuitePro -Xmx200m --collaborator-server --collaborator-config=/usr/local/collaborator/collaborator.config


### PR DESCRIPTION
Adding -Xmx200m as per: https://portswigger.net/burp/documentation/collaborator/deploying#installation-and-execution and https://portswigger.net/burp/documentation/desktop/getting-started/launching/command-line 

This limits max memory usage, especially necessary on small instances. Otherwise burp will use all available memory causing the system to become unresponsive.