### PR TITLE
Update collaborator.config

### DIFF
--- a/collaborator.config
+++ b/collaborator.config
@@ -50,5 +50,5 @@
     }], 
     "ports" : 53
   }, 
-  "logLevel" : "DEBUG" 
+  "logLevel" : "INFO" 
 }


### PR DESCRIPTION
Setting logLevel to the default "INFO" value as per: https://portswigger.net/burp/documentation/collaborator/deploying#collaborator-logging
DEBUG discloses details of Collaborator interactions and polling, including source IP address and interaction IDs. This might disclose sensitive information in the log output which is not a desired default behavior.